### PR TITLE
Fix Windows detection on older Chef versions

### DIFF
--- a/libraries/ruby_install.rb
+++ b/libraries/ruby_install.rb
@@ -28,7 +28,7 @@ class Chef
     attribute :version,     kind_of: String, name_attribute: true
     attribute :environment, kind_of: Hash, default: {}
     attribute :patches,     kind_of: Array, default: []
-    attribute :prefix,      kind_of: String, default: lazy { |r| ChefConfig.windows? ? ::File.join(ENV['SYSTEMDRIVE'], 'rubies', r.version) : "/opt/rubies/ruby-#{r.version}" }
+    attribute :prefix,      kind_of: String, default: lazy { |r| Chef::Platform.windows? ? ::File.join(ENV['SYSTEMDRIVE'], 'rubies', r.version) : "/opt/rubies/ruby-#{r.version}" }
 
     def patch(patch)
       @patches << patch

--- a/libraries/rust_install.rb
+++ b/libraries/rust_install.rb
@@ -26,7 +26,7 @@ class Chef
 
     attribute :version, kind_of: String, name_attribute: true
     attribute :channel, kind_of: String, default: 'stable'
-    attribute :prefix, kind_of: String, default: lazy { ChefConfig.windows? ? nil : '/usr/local' }
+    attribute :prefix, kind_of: String, default: lazy { Chef::Platform.windows? ? nil : '/usr/local' }
   end
 end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'releng@chef.io'
 license 'Apache 2.0'
 description 'Installs/Configures languages'
 long_description 'Installs/Configures languages'
-version '0.1.8'
+version '0.1.9'
 
 depends 'chef-sugar', '~> 3.1'
 depends 'build-essential', '~> 2.2'


### PR DESCRIPTION
The `ChefConfig` class is only available on recent versions of Chef.

/cc @chef-cookbooks/delivery-migration-team 
