### PR TITLE
Specify supported platform families in platform-specific providers

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,7 +3,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 12.5.1
+  require_chef_omnibus: <%= ENV['CHEF_VERSION'] || '12.5.1' %>
 
 platforms:
   - name: centos-6.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,14 @@ services:
 
 env:
   matrix:
-    - LANGUAGE=erlang
-    - LANGUAGE=node
-    - LANGUAGE=ruby
-    - LANGUAGE=rust
+    - CHEF_VERSION=12.0.3 LANGUAGE=erlang
+    - CHEF_VERSION=12.0.3 LANGUAGE=node
+    - CHEF_VERSION=12.0.3 LANGUAGE=ruby
+    - CHEF_VERSION=12.0.3 LANGUAGE=rust
+    - CHEF_VERSION=latest LANGUAGE=erlang
+    - CHEF_VERSION=latest LANGUAGE=node
+    - CHEF_VERSION=latest LANGUAGE=ruby
+    - CHEF_VERSION=latest LANGUAGE=rust
 
 matrix:
   fast_finish: true

--- a/libraries/erlang_install.rb
+++ b/libraries/erlang_install.rb
@@ -93,9 +93,7 @@ class Chef
 
     # Tricks `kerl` to looking for a `.kerlrc` file in Chef's cache
     def kerl_environment
-      {
-        'HOME' => kerl_path,
-      }
+      { 'HOME' => kerl_path }
     end
 
     def build_erlang

--- a/libraries/ruby_install.rb
+++ b/libraries/ruby_install.rb
@@ -25,7 +25,15 @@ class Chef
   end
 
   class Provider::RubyInstall < Provider::LanguageInstall
-    provides :ruby_install
+    provides :ruby_install,
+             platform_family: %w(
+               aix
+               debian
+               freebsd
+               mac_os_x
+               rhel
+               solaris2
+             )
 
     RUBY_INSTALL_VERSION  = '0.4.1'.freeze
     RUBY_INSTALL_CHECKSUM = '1b35d2b6dbc1e75f03fff4e8521cab72a51ad67e32afd135ddc4532f443b730e'.freeze

--- a/libraries/rust_install.rb
+++ b/libraries/rust_install.rb
@@ -30,7 +30,15 @@ end
 
 class Chef
   class Provider::RustInstall < Provider::LanguageInstall
-    provides :rust_install
+    provides :rust_install,
+             platform_family: %w(
+               aix
+               debian
+               freebsd
+               mac_os_x
+               rhel
+               solaris2
+             )
 
     #
     # @see Chef::Resource::LanguageInstall#installed?

--- a/test/fixtures/cookbooks/languages_erlang/metadata.rb
+++ b/test/fixtures/cookbooks/languages_erlang/metadata.rb
@@ -1,4 +1,3 @@
 name 'languages_erlang'
 
 depends 'languages'
-depends 'fancy_execute'

--- a/test/fixtures/cookbooks/languages_node/metadata.rb
+++ b/test/fixtures/cookbooks/languages_node/metadata.rb
@@ -1,4 +1,3 @@
 name 'languages_node'
 
 depends 'languages'
-depends 'fancy_execute'

--- a/test/fixtures/cookbooks/languages_ruby/metadata.rb
+++ b/test/fixtures/cookbooks/languages_ruby/metadata.rb
@@ -1,4 +1,3 @@
 name 'languages_ruby'
 
 depends 'languages'
-depends 'fancy_execute'

--- a/test/fixtures/cookbooks/languages_rust/metadata.rb
+++ b/test/fixtures/cookbooks/languages_rust/metadata.rb
@@ -1,4 +1,3 @@
 name 'languages_rust'
 
 depends 'languages'
-depends 'fancy_execute'


### PR DESCRIPTION
This ensures the provider mapping works correctly on older versions of Chef (*cough* `12.0.x`).

/cc @chef-cookbooks/engineering-services 
