### PR TITLE
Use legacy `git-core` package name on Debian/Ubuntu

### DIFF
--- a/libraries/language_install.rb
+++ b/libraries/language_install.rb
@@ -67,7 +67,7 @@ class Chef
         case node.platform_family
         when 'debian'
           package 'curl'
-          package 'git'
+          package 'git-core'
           package 'libxml2-dev'
           package 'libxslt-dev'
           package 'zlib1g-dev'


### PR DESCRIPTION
Recent versions of Debian and Ubuntu now use a package name of `git` but have kept a `git-core` meta package around for backward combat. We’ll install the `git-core` package for backward compatibility. More details here: 

http://askubuntu.com/questions/5930/what-are-the-differences-between-the-git-and-git-core-packages

/cc @chef-cookbooks/engineering-services 