### PR TITLE
Updating kerl to follow master as well kerl org.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,9 @@ RaiseArgs:
   Enabled: false
 SignalException:
   Enabled: false
-SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: false
-TrailingComma:
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma

--- a/libraries/_helper.rb
+++ b/libraries/_helper.rb
@@ -72,7 +72,7 @@ module Languages
     # @param [Proc] block
     #   the block to execute with the cleaned environment
     #
-    def with_clean_env(&block)
+    def with_clean_env(&_block)
       original = ENV.to_hash
 
       ENV.delete('_ORIGINAL_GEM_PATH')
@@ -80,7 +80,7 @@ module Languages
       ENV.delete_if { |k, _| k.start_with?('GEM_') }
       ENV.delete_if { |k, _| k.start_with?('RUBY') }
 
-      block.call
+      yield
     ensure
       ENV.replace(original.to_hash)
     end

--- a/libraries/erlang_install.rb
+++ b/libraries/erlang_install.rb
@@ -29,7 +29,7 @@ class Chef
   class Provider::ErlangInstall < Provider::LanguageInstall
     provides :erlang_install
 
-    KERL_SHA = '4e7c4349ddcd46ac11cd4cd50bfbda25f1f11ca2'.freeze
+    KERL_SHA = 'master'.freeze
 
     #
     # @see Chef::Resource::LanguageInstall#installed?
@@ -56,7 +56,7 @@ class Chef
 
       # install kerl
       kerl_install = Chef::Resource::RemoteFile.new(::File.join(kerl_path, 'kerl'), run_context)
-      kerl_install.source("https://raw.githubusercontent.com/yrashk/kerl/#{KERL_SHA}/kerl")
+      kerl_install.source("https://raw.githubusercontent.com/kerl/kerl/#{KERL_SHA}/kerl")
       kerl_install.mode('0755')
       kerl_install.sensitive(true)
       kerl_install.run_action(:create)

--- a/libraries/language_install.rb
+++ b/libraries/language_install.rb
@@ -85,6 +85,7 @@ class Chef
         when 'rhel'
           package 'curl'
           package 'bzip2'
+          package 'file'
           package 'git'
           package 'libxml2-devel'
           package 'libxslt-devel'

--- a/test/fixtures/cookbooks/languages_ruby/recipes/default.rb
+++ b/test/fixtures/cookbooks/languages_ruby/recipes/default.rb
@@ -46,11 +46,11 @@ end
 #########################################################################
 # Non-default Prefix
 #########################################################################
-if Chef::Platform.windows?
-  alternate_prefix = 'C:/ruby'
-else
-  alternate_prefix = '/usr/local'
-end
+alternate_prefix = if Chef::Platform.windows?
+                     'C:/ruby'
+                   else
+                     '/usr/local'
+                   end
 
 ruby_install '2.1.5' do
   prefix alternate_prefix

--- a/test/fixtures/cookbooks/languages_rust/recipes/default.rb
+++ b/test/fixtures/cookbooks/languages_rust/recipes/default.rb
@@ -20,7 +20,7 @@ version = "0.0.1"
 authors = ["Fakey McFake <fake@chef.io>"]
 
 [dependencies]
-regex = "*"
+toml = "*"
   EOF
   sensitive true
   action :create

--- a/test/fixtures/cookbooks/languages_rust/recipes/default.rb
+++ b/test/fixtures/cookbooks/languages_rust/recipes/default.rb
@@ -34,11 +34,11 @@ end
 #########################################################################
 # Non-default Prefix
 #########################################################################
-if Chef::Platform.windows?
-  alternate_prefix = 'C:/rust'
-else
-  alternate_prefix = '/usr/local'
-end
+alternate_prefix = if Chef::Platform.windows?
+                     'C:/rust'
+                   else
+                     '/usr/local'
+                   end
 
 rust_install '2015-07-31' do
   channel 'beta'

--- a/test/integration/languages_rust/serverspec/languages_rust_spec.rb
+++ b/test/integration/languages_rust/serverspec/languages_rust_spec.rb
@@ -21,5 +21,5 @@ describe file("#{chef_file_cache}/fake/target/debug/libfake.rlib"), if: !windows
 end
 
 describe file("#{chef_file_cache}/fake/Cargo.lock") do
-  its(:content) { should match 'regex' }
+  its(:content) { should match 'toml' }
 end


### PR DESCRIPTION
The version of kerl we were pinned to has a reference to the old
download page for OTP. The new version should look at the most recent
page.