### PR TITLE
Release 0.3.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'releng@chef.io'
 license 'Apache 2.0'
 description 'Installs/Configures languages'
 long_description 'Installs/Configures languages'
-version '0.2.8'
+version '0.3.0'
 
 source_url 'https://github.com/chef-cookbooks/languages'
 issues_url 'https://github.com/chef-cookbooks/languages/issues'


### PR DESCRIPTION
Release 0.3.0 of cookbook. 

The minor version has been bumped due to the shenanigans with how paths are handled by `kerl` for installing erlang.

/cc @chef-cookbooks/engineering-services 